### PR TITLE
Added support for handlebars templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
 			{
 				"language": "html",
 				"path": "./snippets/snippets.json"
+			},
+			{
+				"language": "handlebars",
+				"path": "./snippets/snippets.json"
 			}
 		]
 	}


### PR DESCRIPTION
Used the same snippets file as for Html but applied to [Handlebars](http://handlebarsjs.com/) templates. No doubt the same pattern can be applied to other html-esque templating languages.